### PR TITLE
Fixes to R CMD check error/warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,13 +8,15 @@ Description: This R package allows you to simulate the deterioration of
     Approximately 2.7 million rows of data were collected. This provides the initial
     state of the School Estate at time zero. The deterioration of the School Estate
     is then modelled by using deterioration rates associated with each Construction
-    Elements-Sub-element-construction-type.
+    Elements-Sub-element-construction-type
 Depends:
     R (>= 3.3.1)
 License: GPL-2
 Encoding: UTF-8
 LazyData: true
 Imports:
+    dplyr,
+    tibble,
     tidyverse,
     markovchain
 URL: https://about.me/mammykins
@@ -22,5 +24,7 @@ BugReports: https://github.com/mammykins/blockbuster/issues
 RoxygenNote: 5.0.1
 Suggests: testthat,
     knitr,
-    rmarkdown
+    rmarkdown,
+    govstyle,
+    devtools
 VignetteBuilder: knitr

--- a/R/deteriorate.R
+++ b/R/deteriorate.R
@@ -162,8 +162,10 @@ blockbust <- function(blockbuster_tibble) {
 #'  other variables and values from the input tibble.
 #' After each timestep is simulated the rows are aggregated by \code{elementid} and \code{grade}.
 #' @seealso 
+#' @importFrom stats aggregate
 #' @export
 #' @examples 
+#'
 #' two_year_later <- blockbuster(dplyr::filter(blockbuster_pds, buildingid == 127617), 2)
 #' 
 blockbuster <- function(blockbuster_tibble, forecast_horizon) {

--- a/vignettes/blockbuster_vignette.Rmd
+++ b/vignettes/blockbuster_vignette.Rmd
@@ -135,7 +135,7 @@ devtools::install_github('mangothecat/visualTest')  #  required for govstyle
 devtools::install_github("UKGov-Data-Science/govstyle")
 
 p <- ggplot(data = df, aes(x = grade, y = unit_area)) +
-  geom_bar(stat = "identity") +
+  geom_bar(stat = "identity", fill = gov_cols['turquoise']) +
   xlab("Condition") +
   ylab(expression(paste(
   "Unit area (",m^2,


### PR DESCRIPTION
* Added `dplyr`, `tibble` to imports
* Added `govstyle` to suggests for vignette. Since this is a github
package, this makes sense; if it was imported rather than suggested, it
would make install impossible for those unable to use `devtools`.
* Added `devtools` to suggests for the same reason. Note that some govt
machines cannot install `devtools` either, so a suggests is better here,
rather than an import.
* Removed full stop at end of `DESCRIPTION`.
* Made use of `govstyle::gov_cols` to add colour to plot.